### PR TITLE
[초기세팅]: 라우트, globalcss, 헤더, H2,H3

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,17 +8,24 @@ import GlobalStyle from "./GlobalStyle";
 import FieldCamp from "./pages/FieldCamp";
 import FieldNews from "./pages/FieldNews";
 import Contact from "./pages/Contact";
+import Sns from "./pages/Sns";
+import Layout from "./layout/Layout";
+import Album from "./pages/Album";
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Routes>
-        <Route path='/' element={<MainPage />} />
-        <Route path='/about' element={<AboutField />} />
-        <Route path='/camp' element={<FieldCamp />} />
-        <Route path='/news' element={<FieldNews />} />
-        <Route path='/contact' element={<Contact />} />
+        <Route element={<Layout />}>
+          <Route path='/' element={<MainPage />} />
+          <Route path='/about' element={<AboutField />} />
+          <Route path='/camp' element={<FieldCamp />} />
+          <Route path='/news' element={<FieldNews />} />
+          <Route path='/contact' element={<Contact />} />
+          <Route path='/sns' element={<Sns />} />
+          <Route path='/album' element={<Album />} />
+        </Route>
       </Routes>
     </ThemeProvider>
   );

--- a/src/GlobalStyle.jsx
+++ b/src/GlobalStyle.jsx
@@ -1,7 +1,11 @@
 import {createGlobalStyle} from "styled-components";
+import theme from "./theme";
 
 const GlobalStyle = createGlobalStyle`
-html,
+html{
+    background : ${theme.colors.primary};
+    color: ${theme.colors.white}
+},
 body,
 div,
 span,
@@ -9,7 +13,9 @@ applet,
 object,
 iframe,
 h1,
-h2,
+h2
+        
+,
 h3,
 h4,
 h5,

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
-import resetcs
-
+@font-face {
+  font-family: "arialBlack";
+  src: url("fonts/ARIALBI.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import styled from "styled-components";
 
-function Header() {
-  return <div>Header</div>;
+const TopInfo = styled.div`
+  background-color: black;
+  height: 4rem;
+  position: sticky;
+  top: 0;
+`;
+
+export default function Header() {
+  return <TopInfo>Header</TopInfo>;
 }
-
-export default Header;

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import {Outlet} from "react-router-dom";
+import Header from "./Header";
+
+function Layout() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+}
+
+export default Layout;

--- a/src/pages/Album.jsx
+++ b/src/pages/Album.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Album() {
+  return <div>Album</div>;
+}

--- a/src/styles/H2.jsx
+++ b/src/styles/H2.jsx
@@ -2,9 +2,12 @@ import styled from "styled-components";
 import theme from "../theme";
 
 const H2 = styled.h2`
-  font-size: ${props => (props.size ? props.size : "1rem")};
-  color: ${props => (props.color ? theme.colors[props.color] : theme.colors.primary)};
-  font-family: ${props => (props.family ? props.family : "sans-serif")};
+  font-size: ${props => (props.size ? props.size : "2rem")};
+  color: ${props => (props.color ? theme.colors[props.color] : theme.colors.white)};
+  margin: ${props => (props.padding ? props.padding : "2rem 0 2rem 0")};
+  font-family: 'Goblin One', serif;
+  text-align: center;
+};
 `;
 
 export default H2;

--- a/src/styles/H3.jsx
+++ b/src/styles/H3.jsx
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+import theme from "../theme";
+
+const H3 = styled.h3`
+  font-size: ${props => (props.size ? props.size : "1.5rem")};
+  color: ${props => (props.color ? theme.colors[props.color] : theme.colors.white)};
+  font-family: serif;
+  text-align: center;
+};
+`;
+
+export default H3;


### PR DESCRIPTION
### 📝 Description

라우트 설정과 page컴포넌트 설정, 재사용가능한 스타일 컴포넌트 생성, 헤더 생성

### 💽 Commits

ex) 구현 사항 요약

1. 라우트와 page추가
2. globalcss 배경,글씨 색깔 추가
3. H2,H3 스타일 컴포넌트 수정
4. 헤더 생성

### 🖼 Result

생략
